### PR TITLE
Update hinting metadata

### DIFF
--- a/Italic/Instances/BlackIt/font.ufo/fontinfo.plist
+++ b/Italic/Instances/BlackIt/font.ufo/fontinfo.plist
@@ -128,12 +128,10 @@
 		<key>postscriptStemSnapH</key>
 		<array>
 			<integer>134</integer>
-			<integer>144</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>172</integer>
-			<integer>176</integer>
+			<integer>164</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Instances/BlackIt/fontinfo
+++ b/Italic/Instances/BlackIt/fontinfo
@@ -17,7 +17,7 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -176
 	DescenderOvershoot -12
-	DominantV [172]
+	DominantV [164]
 	DominantH [134]
 	FlexOK false
 end FDDict LOWERCASE
@@ -27,7 +27,7 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 650
 	CapOvershoot 12
-	DominantV [176]
+	DominantV [164]
 	DominantH [134]
 	FlexOK false
 end FDDict UPPERCASE
@@ -37,7 +37,7 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 634
 	FigOvershoot 12
-	DominantV [176]
+	DominantV [164]
 	DominantH [134]
 	FlexOK false
 end FDDict FIGURES
@@ -47,7 +47,7 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 580
 	FigOvershoot 12
-	DominantV [176]
+	DominantV [164]
 	DominantH [134]
 	FlexOK false
 end FDDict TEXT_FIGURES

--- a/Italic/Instances/BoldIt/font.ufo/fontinfo.plist
+++ b/Italic/Instances/BoldIt/font.ufo/fontinfo.plist
@@ -128,12 +128,10 @@
 		<key>postscriptStemSnapH</key>
 		<array>
 			<integer>116</integer>
-			<integer>126</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>147</integer>
-			<integer>154</integer>
+			<integer>141</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Instances/BoldIt/fontinfo
+++ b/Italic/Instances/BoldIt/fontinfo
@@ -13,12 +13,12 @@ begin FDDict LOWERCASE
 	BaselineOvershoot -12
 	LcHeight 496
 	LcOvershoot 12
-	AscenderHeight 701
+	AscenderHeight 700
 	AscenderOvershoot 12
 	DescenderHeight -184
 	DescenderOvershoot -12
-	DominantV [146]
-	DominantH [115]
+	DominantV [141]
+	DominantH [116]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 652
 	CapOvershoot 12
-	DominantV [150]
-	DominantH [115]
+	DominantV [141]
+	DominantH [116]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 635
 	FigOvershoot 12
-	DominantV [150]
-	DominantH [115]
+	DominantV [141]
+	DominantH [116]
 	FlexOK false
 end FDDict FIGURES
 
@@ -47,8 +47,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 578
 	FigOvershoot 12
-	DominantV [150]
-	DominantH [115]
+	DominantV [141]
+	DominantH [116]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Italic/Instances/ExtraLightIt/font.ufo/fontinfo.plist
+++ b/Italic/Instances/ExtraLightIt/font.ufo/fontinfo.plist
@@ -127,13 +127,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>28</integer>
-			<integer>40</integer>
+			<integer>26</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>32</integer>
-			<integer>48</integer>
+			<integer>28</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Instances/ExtraLightIt/fontinfo
+++ b/Italic/Instances/ExtraLightIt/fontinfo
@@ -17,8 +17,8 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -222
 	DescenderOvershoot -12
-	DominantV [44]
-	DominantH [40]
+	DominantV [28]
+	DominantH [26]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 660
 	CapOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [28]
+	DominantH [26]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 640
 	FigOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [28]
+	DominantH [26]
 	FlexOK false
 end FDDict FIGURES
 
@@ -47,8 +47,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 570
 	FigOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [28]
+	DominantH [26]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Italic/Instances/It/font.ufo/fontinfo.plist
+++ b/Italic/Instances/It/font.ufo/fontinfo.plist
@@ -128,12 +128,10 @@
 		<key>postscriptStemSnapH</key>
 		<array>
 			<integer>67</integer>
-			<integer>78</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>84</integer>
-			<integer>95</integer>
+			<integer>79</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Instances/It/fontinfo
+++ b/Italic/Instances/It/fontinfo
@@ -17,8 +17,8 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -205
 	DescenderOvershoot -12
-	DominantV [82]
-	DominantH [68]
+	DominantV [79]
+	DominantH [67]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 656
 	CapOvershoot 12
-	DominantV [86]
-	DominantH [68]
+	DominantV [79]
+	DominantH [67]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 638
 	FigOvershoot 12
-	DominantV [86]
-	DominantH [68]
+	DominantV [79]
+	DominantH [67]
 	FlexOK false
 end FDDict FIGURES
 
@@ -47,8 +47,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 574
 	FigOvershoot 12
-	DominantV [86]
-	DominantH [68]
+	DominantV [79]
+	DominantH [67]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Italic/Instances/LightIt/font.ufo/fontinfo.plist
+++ b/Italic/Instances/LightIt/font.ufo/fontinfo.plist
@@ -127,13 +127,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>39</integer>
-			<integer>50</integer>
+			<integer>37</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>46</integer>
-			<integer>61</integer>
+			<integer>42</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Instances/LightIt/fontinfo
+++ b/Italic/Instances/LightIt/fontinfo
@@ -17,8 +17,8 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -217
 	DescenderOvershoot -12
-	DominantV [44]
-	DominantH [40]
+	DominantV [42]
+	DominantH [37]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 659
 	CapOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [42]
+	DominantH [37]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 639
 	FigOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [42]
+	DominantH [37]
 	FlexOK false
 end FDDict FIGURES
 
@@ -47,8 +47,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 571
 	FigOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [42]
+	DominantH [37]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Italic/Instances/SemiboldIt/font.ufo/fontinfo.plist
+++ b/Italic/Instances/SemiboldIt/font.ufo/fontinfo.plist
@@ -127,13 +127,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>92</integer>
-			<integer>102</integer>
+			<integer>93</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>116</integer>
-			<integer>125</integer>
+			<integer>111</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Instances/SemiboldIt/fontinfo
+++ b/Italic/Instances/SemiboldIt/fontinfo
@@ -15,10 +15,10 @@ begin FDDict LOWERCASE
 	LcOvershoot 12
 	AscenderHeight 706
 	AscenderOvershoot 12
-	DescenderHeight -193
+	DescenderHeight -194
 	DescenderOvershoot -12
-	DominantV [116]
-	DominantH [94]
+	DominantV [111]
+	DominantH [93]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 654
 	CapOvershoot 12
-	DominantV [120]
-	DominantH [94]
+	DominantV [111]
+	DominantH [93]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 636
 	FigOvershoot 12
-	DominantV [120]
-	DominantH [94]
+	DominantV [111]
+	DominantH [93]
 	FlexOK false
 end FDDict FIGURES
 
@@ -47,8 +47,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 576
 	FigOvershoot 12
-	DominantV [120]
-	DominantH [94]
+	DominantV [111]
+	DominantH [93]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Italic/Masters/master_0/SourceSans_ExtraLight-Italic.ufo/fontinfo.plist
+++ b/Italic/Masters/master_0/SourceSans_ExtraLight-Italic.ufo/fontinfo.plist
@@ -127,13 +127,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>28</integer>
-			<integer>40</integer>
+			<integer>26</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>32</integer>
-			<integer>48</integer>
+			<integer>28</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Masters/master_1/SourceSans_Semibold-Italic.ufo/fontinfo.plist
+++ b/Italic/Masters/master_1/SourceSans_Semibold-Italic.ufo/fontinfo.plist
@@ -127,13 +127,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>92</integer>
-			<integer>102</integer>
+			<integer>93</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>116</integer>
-			<integer>125</integer>
+			<integer>111</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Italic/Masters/master_2/SourceSans_Black-Italic.ufo/fontinfo.plist
+++ b/Italic/Masters/master_2/SourceSans_Black-Italic.ufo/fontinfo.plist
@@ -76,12 +76,10 @@
 		<key>postscriptStemSnapH</key>
 		<array>
 			<integer>134</integer>
-			<integer>144</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
-			<integer>172</integer>
-			<integer>176</integer>
+			<integer>164</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/Black/font.ufo/fontinfo.plist
+++ b/Roman/Instances/Black/font.ufo/fontinfo.plist
@@ -136,13 +136,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>134</integer>
 			<integer>144</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>172</integer>
-			<integer>176</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/Black/fontinfo
+++ b/Roman/Instances/Black/fontinfo
@@ -11,14 +11,14 @@ LicenseCode	ADOBE
 begin FDDict LOWERCASE
 	BaselineYCoord 0
 	BaselineOvershoot -12
-	LcHeight 498
+	LcHeight 500
 	LcOvershoot 12
-	AscenderHeight 698
+	AscenderHeight 696
 	AscenderOvershoot 12
-	DescenderHeight -179
+	DescenderHeight -176
 	DescenderOvershoot -12
 	DominantV [172]
-	DominantH [134]
+	DominantH [144]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,18 +27,18 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 650
 	CapOvershoot 12
-	DominantV [176]
-	DominantH [134]
+	DominantV [172]
+	DominantH [144]
 	FlexOK false
 end FDDict UPPERCASE
 
 begin FDDict SMALLCAPS
 	BaselineYCoord 0
 	BaselineOvershoot -12
-	CapHeight 530
+	CapHeight 532
 	CapOvershoot 12
 	DominantV [172]
-	DominantH [134]
+	DominantH [144]
 	FlexOK false
 end FDDict SMALLCAPS
 
@@ -47,18 +47,18 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 634
 	FigOvershoot 12
-	DominantV [176]
-	DominantH [134]
+	DominantV [172]
+	DominantH [144]
 	FlexOK false
 end FDDict FIGURES
 
 begin FDDict TEXT_FIGURES
 	BaselineYCoord 0
 	BaselineOvershoot -12
-	FigHeight 579
+	FigHeight 580
 	FigOvershoot 12
-	DominantV [176]
-	DominantH [134]
+	DominantV [172]
+	DominantH [144]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Roman/Instances/Bold/font.ufo/fontinfo.plist
+++ b/Roman/Instances/Bold/font.ufo/fontinfo.plist
@@ -136,13 +136,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>116</integer>
-			<integer>126</integer>
+			<integer>125</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>147</integer>
-			<integer>154</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/Bold/fontinfo
+++ b/Roman/Instances/Bold/fontinfo
@@ -13,12 +13,12 @@ begin FDDict LOWERCASE
 	BaselineOvershoot -12
 	LcHeight 496
 	LcOvershoot 12
-	AscenderHeight 701
+	AscenderHeight 700
 	AscenderOvershoot 12
 	DescenderHeight -184
 	DescenderOvershoot -12
-	DominantV [146]
-	DominantH [115]
+	DominantV [147]
+	DominantH [125]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,18 +27,18 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 652
 	CapOvershoot 12
-	DominantV [150]
-	DominantH [115]
+	DominantV [147]
+	DominantH [125]
 	FlexOK false
 end FDDict UPPERCASE
 
 begin FDDict SMALLCAPS
 	BaselineYCoord 0
 	BaselineOvershoot -12
-	CapHeight 527
+	CapHeight 528
 	CapOvershoot 12
-	DominantV [146]
-	DominantH [115]
+	DominantV [147]
+	DominantH [125]
 	FlexOK false
 end FDDict SMALLCAPS
 
@@ -47,8 +47,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 635
 	FigOvershoot 12
-	DominantV [150]
-	DominantH [115]
+	DominantV [147]
+	DominantH [125]
 	FlexOK false
 end FDDict FIGURES
 
@@ -57,8 +57,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 578
 	FigOvershoot 12
-	DominantV [150]
-	DominantH [115]
+	DominantV [147]
+	DominantH [125]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Roman/Instances/ExtraLight/font.ufo/fontinfo.plist
+++ b/Roman/Instances/ExtraLight/font.ufo/fontinfo.plist
@@ -137,12 +137,10 @@
 		<key>postscriptStemSnapH</key>
 		<array>
 			<integer>28</integer>
-			<integer>40</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>32</integer>
-			<integer>48</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/ExtraLight/fontinfo
+++ b/Roman/Instances/ExtraLight/fontinfo
@@ -17,8 +17,8 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -222
 	DescenderOvershoot -12
-	DominantV [44]
-	DominantH [40]
+	DominantV [32]
+	DominantH [28]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 660
 	CapOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [32]
+	DominantH [28]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict SMALLCAPS
 	BaselineOvershoot -12
 	CapHeight 510
 	CapOvershoot 12
-	DominantV [44]
-	DominantH [40]
+	DominantV [32]
+	DominantH [28]
 	FlexOK false
 end FDDict SMALLCAPS
 
@@ -47,8 +47,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 640
 	FigOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [32]
+	DominantH [28]
 	FlexOK false
 end FDDict FIGURES
 
@@ -57,8 +57,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 570
 	FigOvershoot 12
-	DominantV [48]
-	DominantH [40]
+	DominantV [32]
+	DominantH [28]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Roman/Instances/Light/font.ufo/fontinfo.plist
+++ b/Roman/Instances/Light/font.ufo/fontinfo.plist
@@ -136,13 +136,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>39</integer>
-			<integer>50</integer>
+			<integer>40</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>46</integer>
-			<integer>61</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/Light/fontinfo
+++ b/Roman/Instances/Light/fontinfo
@@ -17,7 +17,7 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -217
 	DescenderOvershoot -12
-	DominantV [44]
+	DominantV [46]
 	DominantH [40]
 	FlexOK false
 end FDDict LOWERCASE
@@ -27,7 +27,7 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 659
 	CapOvershoot 12
-	DominantV [48]
+	DominantV [46]
 	DominantH [40]
 	FlexOK false
 end FDDict UPPERCASE
@@ -37,7 +37,7 @@ begin FDDict SMALLCAPS
 	BaselineOvershoot -12
 	CapHeight 512
 	CapOvershoot 12
-	DominantV [44]
+	DominantV [46]
 	DominantH [40]
 	FlexOK false
 end FDDict SMALLCAPS
@@ -47,7 +47,7 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 639
 	FigOvershoot 12
-	DominantV [48]
+	DominantV [46]
 	DominantH [40]
 	FlexOK false
 end FDDict FIGURES
@@ -57,7 +57,7 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 571
 	FigOvershoot 12
-	DominantV [48]
+	DominantV [46]
 	DominantH [40]
 	FlexOK false
 end FDDict TEXT_FIGURES

--- a/Roman/Instances/Regular/font.ufo/fontinfo.plist
+++ b/Roman/Instances/Regular/font.ufo/fontinfo.plist
@@ -136,13 +136,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>67</integer>
-			<integer>78</integer>
+			<integer>73</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>84</integer>
-			<integer>95</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/Regular/fontinfo
+++ b/Roman/Instances/Regular/fontinfo
@@ -17,8 +17,8 @@ begin FDDict LOWERCASE
 	AscenderOvershoot 12
 	DescenderHeight -205
 	DescenderOvershoot -12
-	DominantV [82]
-	DominantH [68]
+	DominantV [84]
+	DominantH [73]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,8 +27,8 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 656
 	CapOvershoot 12
-	DominantV [86]
-	DominantH [68]
+	DominantV [84]
+	DominantH [73]
 	FlexOK false
 end FDDict UPPERCASE
 
@@ -37,8 +37,8 @@ begin FDDict SMALLCAPS
 	BaselineOvershoot -12
 	CapHeight 518
 	CapOvershoot 12
-	DominantV [82]
-	DominantH [68]
+	DominantV [84]
+	DominantH [73]
 	FlexOK false
 end FDDict SMALLCAPS
 
@@ -47,8 +47,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 638
 	FigOvershoot 12
-	DominantV [86]
-	DominantH [68]
+	DominantV [84]
+	DominantH [73]
 	FlexOK false
 end FDDict FIGURES
 
@@ -57,8 +57,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 574
 	FigOvershoot 12
-	DominantV [86]
-	DominantH [68]
+	DominantV [84]
+	DominantH [73]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Roman/Instances/Semibold/font.ufo/fontinfo.plist
+++ b/Roman/Instances/Semibold/font.ufo/fontinfo.plist
@@ -136,13 +136,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>92</integer>
-			<integer>102</integer>
+			<integer>101</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>116</integer>
-			<integer>125</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Instances/Semibold/fontinfo
+++ b/Roman/Instances/Semibold/fontinfo
@@ -15,10 +15,10 @@ begin FDDict LOWERCASE
 	LcOvershoot 12
 	AscenderHeight 706
 	AscenderOvershoot 12
-	DescenderHeight -193
+	DescenderHeight -194
 	DescenderOvershoot -12
 	DominantV [116]
-	DominantH [94]
+	DominantH [101]
 	FlexOK false
 end FDDict LOWERCASE
 
@@ -27,18 +27,18 @@ begin FDDict UPPERCASE
 	BaselineOvershoot -12
 	CapHeight 654
 	CapOvershoot 12
-	DominantV [120]
-	DominantH [94]
+	DominantV [116]
+	DominantH [101]
 	FlexOK false
 end FDDict UPPERCASE
 
 begin FDDict SMALLCAPS
 	BaselineYCoord 0
 	BaselineOvershoot -12
-	CapHeight 524
+	CapHeight 523
 	CapOvershoot 12
 	DominantV [116]
-	DominantH [94]
+	DominantH [101]
 	FlexOK false
 end FDDict SMALLCAPS
 
@@ -47,8 +47,8 @@ begin FDDict FIGURES
 	BaselineOvershoot -12
 	FigHeight 636
 	FigOvershoot 12
-	DominantV [120]
-	DominantH [94]
+	DominantV [116]
+	DominantH [101]
 	FlexOK false
 end FDDict FIGURES
 
@@ -57,8 +57,8 @@ begin FDDict TEXT_FIGURES
 	BaselineOvershoot -12
 	FigHeight 576
 	FigOvershoot 12
-	DominantV [120]
-	DominantH [94]
+	DominantV [116]
+	DominantH [101]
 	FlexOK false
 end FDDict TEXT_FIGURES
 

--- a/Roman/Masters/master_0/SourceSans_ExtraLight.ufo/fontinfo.plist
+++ b/Roman/Masters/master_0/SourceSans_ExtraLight.ufo/fontinfo.plist
@@ -157,12 +157,10 @@
 		<key>postscriptStemSnapH</key>
 		<array>
 			<integer>28</integer>
-			<integer>40</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>32</integer>
-			<integer>48</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Masters/master_1/SourceSans_Semibold.ufo/fontinfo.plist
+++ b/Roman/Masters/master_1/SourceSans_Semibold.ufo/fontinfo.plist
@@ -136,13 +136,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>92</integer>
-			<integer>102</integer>
+			<integer>101</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>116</integer>
-			<integer>125</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>

--- a/Roman/Masters/master_2/SourceSans_Black.ufo/fontinfo.plist
+++ b/Roman/Masters/master_2/SourceSans_Black.ufo/fontinfo.plist
@@ -105,13 +105,11 @@
 		</array>
 		<key>postscriptStemSnapH</key>
 		<array>
-			<integer>134</integer>
 			<integer>144</integer>
 		</array>
 		<key>postscriptStemSnapV</key>
 		<array>
 			<integer>172</integer>
-			<integer>176</integer>
 		</array>
 		<key>postscriptUnderlinePosition</key>
 		<integer>-75</integer>


### PR DESCRIPTION
While working on something else, I noticed that some of the hinting metadata had gone out of sync between Source Sans instance UFOs and the adjacent fontinfo files. Attempting a fix, I realized that 2 stem values per hinting direction seemed improbable.

For example, the ExtraLight style used to have `V32`, `V48`, `H28`, `H40`. 
`psstemhist -a -g A-Z,a-z font.ufo` gives us
```
Vertical Stem List for Roman/Instances/ExtraLight/font.ufo
count    width    glyphs
   37       32    [B D E F G H I J K L M P R S T U Y a b c d e g o p q s]
   26       30    [M N U a b d e f h i j k l m n p q r t u]
    9       34    [C D G O P Q R]

Horizontal Stem List for /Roman/Instances/ExtraLight/font.ufo
count    width    glyphs
   57       28    [A B D E F G H L M P R T Z a b c d e f g h j l m n o p q s t u z]
   15       30    [C G J O Q S U r w y]
    3       32    [Q g v]

```
My conclusion is that the `V48` and `H40` stems are superfluous here.

The Black style (where more contrast is seen) used to have `V172`, `V176`, `H134`, `H144`.
`psstemhist -a -g A-Z,a-z font.ufo` gives us
```
Vertical Stem List for /Roman/Instances/Black/font.ufo
count    width    glyphs
   35      172    [B D E F H I J K L P R T U Y a b d f h i j l m n p q r t u]
   15      176    [C D G O Q S b c d o p q]
    4      168    [B P R]
    4      164    [N a g]

Horizontal Stem List for /Roman/Instances/Black/font.ufo
count    width    glyphs
   11      148    [C G J O Q S U]
    9      144    [E F L T Z]
    9      140    [G b d p q]
    8      138    [D c l o w]
    8      134    [f j t y z]
    6      136    [P Q R a]
```
The 4-unit difference between `V172` and `V176` is small, so I think a single `V172` stem can handle all. 
I kept `H144` around, to represent the vast majority of stems found in the top 3 glyph groups.

It all is a little less granular now, and possibly you may have objections – but I think keeping it simple is worth a try.

---

Beyond updating the stems in the adjacent fontinfo files, some shifted alignment zones were also corrected.