### PR TITLE
Source Sans 3, version 3.052 created 2023/03/30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,12 @@ target
 Source*.otf
 Source*.ttf
 
-# ignore processed glyphs & hashmap in masters:
-*/*/*/master.ufo/glyphs.com.adobe.type.processedGlyphs
-*/*/*/master.ufo/data/com.adobe.type.processedHashMap
-*/*/*/master.ufo/layercontents.plist
-*~
+# ignore background, processed glyphs & hashmap in masters.
+# Unfortunately, it is not possible to entirely ignore layers, because
+# tracebacks are thrown when the layer folders are missing.
+*/Masters/*/master_*/*.ufo/glyphs.com.adobe.type.processedGlyphs/*.glif
+*/Masters/*/master_*/*.ufo/glyphs.com.adobe.type.processedGlyphs/contents.plist
+*/Masters/*/master_*/*.ufo/glyphs.background/*.glif
+*/Masters/*/master_*/*.ufo/glyphs.background/contents.plist
+*/Masters/*/master_*/*.ufo/data/com.adobe.type.processedHashMap
+

--- a/FontMenuNameDB
+++ b/FontMenuNameDB
@@ -10,33 +10,15 @@
 
 [SourceSans3VF-Upright]
 	f=Source Sans 3 VF
-	s=Upright
-
-[SourceSans3VF-ExtraLight]
-	f=Source Sans 3 VF
-	s=Upright Pole 0
-
-[SourceSans3VF-Black]
-	f=Source Sans 3 VF
-	s=Upright Pole 2
-
-#---------------------------------------------------------
+	s=ExtraLight
 
 [SourceSans3VF-Italic]
 	f=Source Sans 3 VF
-	s=Italic
-
-[SourceSans3VF-ExtraLightItalic]
-	f=Source Sans 3 VF
-	s=Italic Pole 0
-
-[SourceSans3VF-BlackItalic]
-	f=Source Sans 3 VF
-	s=Italic Pole 2
+	s=ExtraLight Italic
 
 
 # ====================================================================
-# Instance fonts
+# Instance fonts (statics)
 
 [SourceSans3-ExtraLight]
 	f=Source Sans 3

--- a/Italic/Instances/BlackIt/os2.fea
+++ b/Italic/Instances/BlackIt/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by SourceSans3/features.fea
 
-Panose 2 11 8 3 3 4 3 9 2 4;
+Panose 2 11 9 3 3 4 3 9 2 4;
 XHeight 500;
 WeightClass 900; # Black

--- a/Italic/Instances/BoldIt/os2.fea
+++ b/Italic/Instances/BoldIt/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 7 3 3 4 3 9 2 4;
+Panose 2 11 8 3 3 4 3 9 2 4;
 XHeight 496;
 WeightClass 700; # Bold

--- a/Italic/Instances/MediumIt/os2.fea
+++ b/Italic/Instances/MediumIt/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 5 9 3 4 3 9 2 4;
+Panose 2 11 6 3 3 4 3 9 2 4;
 XHeight 489;
 WeightClass 500; # Medium

--- a/Italic/Instances/SemiboldIt/os2.fea
+++ b/Italic/Instances/SemiboldIt/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 6 3 3 4 3 9 2 4;
+Panose 2 11 7 3 3 4 3 9 2 4;
 XHeight 491;
 WeightClass 600; # Semibold

--- a/Italic/Poles/pole_0/SourceSans3-ExtraLightItalic.ufo/fontinfo.plist
+++ b/Italic/Poles/pole_0/SourceSans3-ExtraLightItalic.ufo/fontinfo.plist
@@ -160,7 +160,7 @@
 		<key>versionMajor</key>
 		<integer>3</integer>
 		<key>versionMinor</key>
-		<integer>48</integer>
+		<integer>52</integer>
 		<key>xHeight</key>
 		<integer>478</integer>
 	</dict>

--- a/Italic/Poles/pole_1/SourceSans3-Italic.ufo/fontinfo.plist
+++ b/Italic/Poles/pole_1/SourceSans3-Italic.ufo/fontinfo.plist
@@ -159,7 +159,7 @@
 		<key>versionMajor</key>
 		<integer>3</integer>
 		<key>versionMinor</key>
-		<integer>48</integer>
+		<integer>52</integer>
 		<key>xHeight</key>
 		<integer>491</integer>
 	</dict>

--- a/Italic/Poles/pole_2/SourceSans3-BlackItalic.ufo/fontinfo.plist
+++ b/Italic/Poles/pole_2/SourceSans3-BlackItalic.ufo/fontinfo.plist
@@ -166,7 +166,7 @@
 		<key>versionMajor</key>
 		<integer>3</integer>
 		<key>versionMinor</key>
-		<integer>48</integer>
+		<integer>52</integer>
 		<key>xHeight</key>
 		<integer>500</integer>
 	</dict>

--- a/Italic/SourceSans3VF-Italic.designspace
+++ b/Italic/SourceSans3VF-Italic.designspace
@@ -128,8 +128,8 @@
 				<string>Ginsular.x</string>
 				<string>Ginsularturned.x</string>
 				<string>oxia.cap</string>
-				<string>Rinsular.sx</string>
 				<string>rinsular.x</string>
+				<string>Rinsular.x</string>
 				<string>Rinsular.xs</string>
 				<string>Sigmoid.sc</string>
 				<string>Ssigmoid</string>

--- a/Upright/Instances/Black/os2.fea
+++ b/Upright/Instances/Black/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 8 3 3 4 3 2 2 4;
+Panose 2 11 9 3 3 4 3 2 2 4;
 XHeight 500;
 WeightClass 900; # Black

--- a/Upright/Instances/Bold/os2.fea
+++ b/Upright/Instances/Bold/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 7 3 3 4 3 2 2 4;
+Panose 2 11 8 3 3 4 3 2 2 4;
 XHeight 496;
 WeightClass 700; # Bold

--- a/Upright/Instances/Medium/os2.fea
+++ b/Upright/Instances/Medium/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 5 9 3 4 3 2 2 4;
+Panose 2 11 6 3 3 4 3 2 2 4;
 XHeight 489;
 WeightClass 500; # Medium

--- a/Upright/Instances/Semibold/os2.fea
+++ b/Upright/Instances/Semibold/os2.fea
@@ -1,5 +1,5 @@
 # inlcuded by /SourceSans3/features.fea
 
-Panose 2 11 6 3 3 4 3 2 2 4;
+Panose 2 11 7 3 3 4 3 2 2 4;
 XHeight 491;
 WeightClass 600; # Semibold

--- a/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/fontinfo.plist
+++ b/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/fontinfo.plist
@@ -161,7 +161,7 @@
 		<key>versionMajor</key>
 		<integer>3</integer>
 		<key>versionMinor</key>
-		<integer>48</integer>
+		<integer>52</integer>
 		<key>xHeight</key>
 		<integer>478</integer>
 	</dict>

--- a/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/glyphs/R_insular.xs.glif
+++ b/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/glyphs/R_insular.xs.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="Rinsular.sx" format="2">
+<glyph name="Rinsular.xs" format="2">
 	<advance width="464"/>
 	<outline>
 		<contour>

--- a/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/glyphs/contents.plist
+++ b/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/glyphs/contents.plist
@@ -1508,10 +1508,10 @@
 		<string>R_insular.glif</string>
 		<key>Rinsular.sc</key>
 		<string>R_insular.sc.glif</string>
-		<key>Rinsular.sx</key>
-		<string>R_insular.sx.glif</string>
 		<key>Rinsular.x</key>
 		<string>R_insular.x.glif</string>
+		<key>Rinsular.xs</key>
+		<string>R_insular.xs.glif</string>
 		<key>Rlinebelow</key>
 		<string>R_linebelow.glif</string>
 		<key>Rlinebelow.sc</key>

--- a/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/lib.plist
+++ b/Upright/Poles/pole_0/SourceSans3-ExtraLight.ufo/lib.plist
@@ -7388,7 +7388,7 @@
 			<string>saxclam.sc</string>
 			<string>huestion.sc</string>
 			<string>suestion.sc</string>
-			<string>Rinsular.sx</string>
+			<string>Rinsular.xs</string>
 			<string>Rinsular.x</string>
 			<string>Ssigmoid</string>
 			<string>aet</string>

--- a/Upright/Poles/pole_1/SourceSans3-Upright.ufo/fontinfo.plist
+++ b/Upright/Poles/pole_1/SourceSans3-Upright.ufo/fontinfo.plist
@@ -159,7 +159,7 @@
 		<key>versionMajor</key>
 		<integer>3</integer>
 		<key>versionMinor</key>
-		<integer>48</integer>
+		<integer>52</integer>
 		<key>xHeight</key>
 		<integer>491</integer>
 	</dict>

--- a/Upright/Poles/pole_2/SourceSans3-Black.ufo/fontinfo.plist
+++ b/Upright/Poles/pole_2/SourceSans3-Black.ufo/fontinfo.plist
@@ -199,7 +199,7 @@
 		<key>versionMajor</key>
 		<integer>3</integer>
 		<key>versionMinor</key>
-		<integer>48</integer>
+		<integer>52</integer>
 		<key>xHeight</key>
 		<integer>500</integer>
 	</dict>

--- a/Upright/SourceSans3VF-Upright.designspace
+++ b/Upright/SourceSans3VF-Upright.designspace
@@ -134,8 +134,8 @@
 				<string>Ginsular.x</string>
 				<string>Ginsularturned.x</string>
 				<string>oxia.cap</string>
-				<string>Rinsular.sx</string>
 				<string>rinsular.x</string>
+				<string>Rinsular.x</string>
 				<string>Rinsular.xs</string>
 				<string>Sigmoid.sc</string>
 				<string>Ssigmoid</string>

--- a/familyTables.fea
+++ b/familyTables.fea
@@ -1,7 +1,7 @@
 # inlcuded by /SourceSans3/features.fea
 
 table head {
-	FontRevision 3.048;
+	FontRevision 3.052;
 } head;
 
 

--- a/familynameIDs.fea
+++ b/familynameIDs.fea
@@ -1,7 +1,7 @@
 # inlcuded by /SourceSans3/features.fea
-# inlcuded by /SourceSans3/featuresVar.fea
+# inlcuded by /SourceSans3/featuresVF.fea
 
-nameid 0 "© 2010 – 2021 Adobe (http://www.adobe.com/), with Reserved Font Name ‘Source’";
+nameid 0 "© 2023 Adobe (http://www.adobe.com/), with Reserved Font Name ‘Source’";
 nameid 7 "Source is a trademark of Adobe in the United States and/or other countries.";
 nameid 8 "Adobe";
 nameid 9 "Paul D. Hunt";

--- a/relnotes.txt
+++ b/relnotes.txt
@@ -1,3 +1,8 @@
+version 3.052 created 2023/03/30
+	Adds Medium weight requested by user. (GitHub issue #253)
+	Updates the design of several glyphs to arrive at more compact vertical metrics.
+
+
 version 3.046 created 2021/07/14
 	Corrects copyright notice. (GitHub issue #223)
 


### PR DESCRIPTION
Adds Medium weight requested by user. (GitHub issue #253) Updates the design of several glyphs to arrive at more compact vertical metrics.