### PR TITLE
Fix font-face paths for variable fonts

### DIFF
--- a/source-sans-3VF.css
+++ b/source-sans-3VF.css
@@ -3,9 +3,9 @@
     font-weight: 200 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('WOFF2/VAR/SourceSans3VF-Upright.ttf.woff2') format('woff2'),
-         url('WOFF/VAR/SourceSans3VF-Upright.ttf.woff') format('woff'),
-         url('VAR/SourceSans3VF-Upright.ttf') format('truetype');
+    src: url('WOFF2/VF/SourceSans3VF-Upright.ttf.woff2') format('woff2'),
+         url('WOFF/VF/SourceSans3VF-Upright.ttf.woff') format('woff'),
+         url('VF/SourceSans3VF-Upright.ttf') format('truetype');
 }
 
 @font-face{
@@ -13,7 +13,7 @@
     font-weight: 200 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('WOFF2/VAR/SourceSans3VF-Italic.ttf.woff2') format('woff2'),
-         url('WOFF/VAR/SourceSans3VF-Italic.ttf.woff') format('woff'),
-         url('VAR/SourceSans3VF-Italic.ttf') format('truetype');
+    src: url('WOFF2/VF/SourceSans3VF-Italic.ttf.woff2') format('woff2'),
+         url('WOFF/VF/SourceSans3VF-Italic.ttf.woff') format('woff'),
+         url('VF/SourceSans3VF-Italic.ttf') format('truetype');
 }


### PR DESCRIPTION
Corrects the paths in the font-face declarations for variable fonts.

This is a similar fix to adobe-fonts/source-code-pro/pull/324, except font names don't have to be updated.